### PR TITLE
chore: Fix CI link to workflow

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -38,6 +38,6 @@ jobs:
           severity: error
           details: |
             Rustc beta tests failed in **${{ github.repository }}**
-            See https://github.com/n0-computer/${{ github.repository }}/actions/workflows/beta.yaml
+            See https://github.com/${{ github.repository }}/actions/workflows/beta.yaml
           webhookUrl: ${{ secrets.DISCORD_N0_GITHUB_CHANNEL_WEBHOOK_URL }}
 


### PR DESCRIPTION
## Description

It used to say:
> See https://github.com/n0-computer/n0-computer/n0-watcher/actions/workflows/beta.yaml

Notice the duplicate `n0-computer`.

Confusingly, `github.repository` is not `n0-watcher`, but `n0-computer/n0-watcher` (but it also makes sense that it's this way).

## Change checklist

- [x] Self-review.
