### PR TITLE
feat!: Make `Watcher::get` take `&mut self` and return a value instead of `Result`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,6 @@ name = "n0-watcher"
 version = "0.2.0"
 dependencies = [
  "derive_more",
- "futures-lite",
  "n0-future",
  "rand",
  "snafu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ name = "n0-watcher"
 version = "0.2.0"
 dependencies = [
  "derive_more",
+ "futures-lite",
  "n0-future",
  "rand",
  "snafu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ snafu = "0.8.6"
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 
 [dev-dependencies]
-futures-lite = "2.6.0"
+n0-future = "0.1.2"
 rand = "0.8"
 tokio = { version = "1", features = ["macros", "sync", "rt-multi-thread", "time", "test-util"] }
 tokio-util = { version = "0.7", features = ["io-util", "io", "rt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ snafu = "0.8.6"
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 
 [dev-dependencies]
+futures-lite = "2.6.0"
 rand = "0.8"
-tokio = { version = "1", features = ["macros", "sync", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "sync", "rt-multi-thread", "time", "test-util"] }
 tokio-util = { version = "0.7", features = ["io-util", "io", "rt"] }
 
 [lints.rust]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ observers to be notified of changes to the value.  The aim is to always be aware
 In that way, a `Watchable` is like a `tokio::sync::broadcast::Sender`, except that there's no risk
 of the channel filling up, but instead you might miss items.
 
+See [the module documentation][https://docs.rs/n0-watcher] for more information.
+
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,23 @@
 //!     }
 //! }
 //! ```
+//!
+//! # Similar but different
+//!
+//! - `async_channel`: This is a multi-producer, multi-consumer channel implementation.
+//!   Only at most one consumer will receive each "produced" value.
+//!   What we want is to have every "produced" value to be "broadcast" to every receiver.
+//! - `tokio::broadcast`: Also a multi-producer, multi-consumer channel implementation.
+//!   This is very similar to this crate (`tokio::broadcast::Sender` is like [`Watchable`]
+//!   and `tokio::broadcast::Receiver` is like [`Watcher`]), but you can't get the latest
+//!   value without `.await`ing on the receiver, and it'll internally store a queue of
+//!   intermediate values.
+//! - [`std::sync::RwLock`]: (wrapped in an [`std::sync::Arc`]) This allows you access
+//!   to the latest values, but might block while it's being set (but that could be short
+//!   enough not to matter for async rust purposes).
+//!   This doesn't allow you to be notified whenever a new value is written.
+//! - The `watchable` crate: We used to use this crate at n0, but we wanted to experience
+//!   with different APIs and needed Wasm support.
 
 #[cfg(not(watcher_loom))]
 use std::sync;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,13 +65,15 @@
 //!   and `tokio::broadcast::Receiver` is like [`Watcher`]), but you can't get the latest
 //!   value without `.await`ing on the receiver, and it'll internally store a queue of
 //!   intermediate values.
+//! - `tokio::watch`: Also a MPSC channel, and unlike `tokio::broadcast` only retains the
+//!   latest value. That module has pretty much the same purpose as this crate, but doesn't
+//!   implement a poll-based method of getting updates and doesn't implement combinators.
 //! - [`std::sync::RwLock`]: (wrapped in an [`std::sync::Arc`]) This allows you access
 //!   to the latest values, but might block while it's being set (but that could be short
 //!   enough not to matter for async rust purposes).
 //!   This doesn't allow you to be notified whenever a new value is written.
-//! - The `watchable` crate: We used to use this crate at n0, but we wanted to experience
+//! - The `watchable` crate: We used to use this crate at n0, but we wanted to experiment
 //!   with different APIs and needed Wasm support.
-
 #[cfg(not(watcher_loom))]
 use std::sync;
 use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,13 @@
 //! # Example
 //!
 //! ```
-//! use n0_watcher::{Watchable, Watcher as _};
 //! use futures_lite::StreamExt;
+//! use n0_watcher::{Watchable, Watcher as _};
 //!
 //! #[tokio::main(flavor = "current_thread", start_paused = true)]
 //! async fn main() {
 //!     let watchable = Watchable::new(None);
-//!     
+//!
 //!     // A task that waits for the watcher to be initialized to Some(value) before printing it
 //!     let mut watcher = watchable.watch();
 //!     tokio::spawn(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! # Example
 //!
 //! ```
-//! use futures_lite::StreamExt;
+//! use n0_future::StreamExt;
 //! use n0_watcher::{Watchable, Watcher as _};
 //!
 //! #[tokio::main(flavor = "current_thread", start_paused = true)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,12 +408,7 @@ impl<T: Clone + Eq, W: Watcher<Value = T>> Watcher for Join<T, W> {
     }
 
     fn is_connected(&self) -> bool {
-        for watcher in &self.watchers {
-            if !watcher.is_connected() {
-                return false;
-            }
-        }
-        true
+        self.watchers.iter().all(|w| w.is_connected())
     }
 
     fn poll_updated(


### PR DESCRIPTION
## Description

Previously: `Watcher::get(&self) -> Result<Self::Value, Disconnected>;`
Now: `Watcher::get(&mut self) -> Self::Value;`

Previously: `Watcher::initialized(&mut self) -> impl Future<Output = Result<Self::Value, Disconnected>>;`
Now: `Watcher::initialized(&mut self) -> impl Future<Output = Self::Value>;`

Added: `Watcher::is_connected(&self) -> bool;`

## Breaking Changes

Well, the API above.

## Notes & open questions

This ends up needing more `Clone`s between `Watchable::set` and `Watcher::get`.
This is very annoying. My hope is that clones in watchables are usually very cheap (and if not, use an `Arc`, what are you doing!), and the better API is worth it.

Also, this adds a `&mut self` where there previously was a `&self` (in `Watcher::get`), but given watchers can be cloned anyways, I don't think this is actually bad at all.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
