### PR TITLE
feat: Implement `Watchable::has_watchers`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,14 @@ impl<T: Clone + Eq> Watchable<T> {
     pub fn get(&self) -> T {
         self.shared.get()
     }
+
+    /// Returns true when there are any watchers actively listening on changes,
+    /// or false when all watchers have been dropped or none have been created yet.
+    pub fn has_watchers(&self) -> bool {
+        // `Watchable`s will increase the strong count
+        // `Direct`s watchers (which all watchers decend from) will increase the weak count
+        Arc::weak_count(&self.shared) != 0
+    }
 }
 
 /// A handle to a value that's represented by one or more underlying [`Watchable`]s.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -905,4 +905,22 @@ mod tests {
             vec![vec![1, 1], vec![2, 1], vec![2, 3], vec![3, 3], vec![3, 4]]
         );
     }
+
+    #[test]
+    fn test_has_watchers() {
+        let a = Watchable::new(1u8);
+        assert!(!a.has_watchers());
+        let b = a.clone();
+        assert!(!a.has_watchers());
+        assert!(!b.has_watchers());
+
+        let watcher = a.watch();
+        assert!(a.has_watchers());
+        assert!(b.has_watchers());
+
+        drop(watcher);
+
+        assert!(!a.has_watchers());
+        assert!(!b.has_watchers());
+    }
 }


### PR DESCRIPTION
## Description

This allows you to check if your `Watchable` is still watched by any other values.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
