### PR TITLE
feat: Don't return `Result` in `Watcher::map`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,7 @@ impl<T> Drop for Watchable<T> {
 /// One of the underlying [`Watchable`]s might already be dropped. In that case,
 /// the watcher will be "disconnected" and return [`Err(Disconnected)`](Disconnected)
 /// on some function calls or, when turned into a stream, that stream will end.
+/// This property can also be checked with [`Watcher::is_connected`].
 pub trait Watcher: Clone {
     /// The type of value that can change.
     ///
@@ -337,16 +338,16 @@ pub trait Watcher: Clone {
     /// Maps this watcher with a function that transforms the observed values.
     ///
     /// The returned watcher will only register updates, when the *mapped* value
-    /// observably changes. For this, it needs to store a clone of `T` in the watcher.
+    /// observably changes.
     fn map<T: Clone + Eq>(
         mut self,
         map: impl Fn(Self::Value) -> T + Send + Sync + 'static,
-    ) -> Result<Map<Self, T>, Disconnected> {
-        Ok(Map {
+    ) -> Map<Self, T> {
+        Map {
             current: (map)(self.get()),
             map: Arc::new(map),
             watcher: self,
-        })
+        }
     }
 
     /// Returns a watcher that updates every time this or the other watcher


### PR DESCRIPTION
## Description

Missed a place where we don't have to return `Result` anymore.

## Breaking Changes

- `Watcher::map` now returns `Map<...>` instead of `Result<Map<...>, Disconnected>`

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.
