### PR TITLE
fix: Remove wakers when dropping `Direct`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +18,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -28,12 +49,6 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -75,6 +90,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,12 +120,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -120,7 +161,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
+ "rustc_version",
  "syn",
  "unicode-xid",
 ]
@@ -138,6 +179,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +199,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -281,6 +342,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +425,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +463,16 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "n0-error"
@@ -416,18 +523,12 @@ dependencies = [
  "derive_more",
  "n0-error",
  "n0-future",
- "procinfo",
+ "procfs",
  "rand",
  "slotmap",
  "tokio",
  "tokio-util",
 ]
-
-[[package]]
-name = "nom"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
 
 [[package]]
 name = "nu-ansi-term"
@@ -436,6 +537,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -496,15 +606,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "procinfo"
-version = "0.4.2"
+name = "procfs"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab1427f3d2635891f842892dda177883dca0639e05fe66796a62c9d2f23b49c"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "byteorder",
- "libc",
- "nom",
- "rustc_version 0.2.3",
+ "bitflags",
+ "chrono",
+ "flate2",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "hex",
 ]
 
 [[package]]
@@ -558,20 +680,24 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.28",
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -588,24 +714,9 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "send_wrapper"
@@ -669,6 +780,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -959,7 +1076,7 @@ dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
- "semver 1.0.28",
+ "semver",
 ]
 
 [[package]]
@@ -973,6 +1090,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1135,15 @@ name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -1082,7 +1243,7 @@ dependencies = [
  "id-arena",
  "indexmap",
  "log",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,7 +120,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "syn",
  "unicode-xid",
 ]
@@ -410,10 +416,18 @@ dependencies = [
  "derive_more",
  "n0-error",
  "n0-future",
+ "procinfo",
  "rand",
+ "slotmap",
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "nom"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
 
 [[package]]
 name = "nu-ansi-term"
@@ -482,6 +496,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "procinfo"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab1427f3d2635891f842892dda177883dca0639e05fe66796a62c9d2f23b49c"
+dependencies = [
+ "byteorder",
+ "libc",
+ "nom",
+ "rustc_version 0.2.3",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,11 +558,20 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -553,9 +588,24 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "send_wrapper"
@@ -625,6 +675,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -791,6 +850,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,7 +959,7 @@ dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -1017,7 +1082,7 @@ dependencies = [
  "id-arena",
  "indexmap",
  "log",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.91"
 derive_more = { version = "2.0.1", features = ["debug"] }
 n0-error = "1.0.0"
 n0-future = "0.3.2"
+slotmap = "1.1.1"
 
 # non-wasm-in-browser dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
@@ -24,6 +25,7 @@ n0-future = "0.3.2"
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 
 [dev-dependencies]
+procinfo = "0.4.2"
 rand = "0.10"
 tokio = { version = "1", features = ["macros", "sync", "rt-multi-thread", "time", "test-util"] }
 tokio-util = { version = "0.7", features = ["io-util", "io", "rt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,12 @@ slotmap = "1.1.1"
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 
 [dev-dependencies]
-procinfo = "0.4.2"
 rand = "0.10"
 tokio = { version = "1", features = ["macros", "sync", "rt-multi-thread", "time", "test-util"] }
 tokio-util = { version = "0.7", features = ["io-util", "io", "rt"] }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+procfs = "0.18.0"
 
 [lints.rust]
 missing_debug_implementations = "warn"

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ allow = [
     "BSD-2-Clause",
     "MIT",
     "Unicode-3.0",
+    "Zlib", # slotmap
 ]
 
 [[licenses.clarify]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1556,8 +1556,10 @@ mod tests {
         }
 
         let mem_use_1 = process.statm().unwrap().resident - mem_baseline;
-        // All N tasks completed and joined, yet their memory stays allocated;
-        // `watchable.set(1)` frees all of it.
+        // All N tasks completed and joined. The watchable should not store any wakers.
+        // Calling `watchable.set(1)` would drain all wakers. In a previous version that
+        // list was non-empty here and draining it would free memory.
+        // In the current version nothing should change.
         watchable.set(1).unwrap();
         let mem_use_2 = process.statm().unwrap().resident - mem_baseline;
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1526,9 +1526,11 @@ mod tests {
             .unwrap()
     }
 
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn regression_memleak() {
-        let mem_baseline = procinfo::pid::statm_self().unwrap().resident;
+        let process = procfs::process::Process::myself().unwrap();
+        let mem_baseline = process.statm().unwrap().resident;
 
         const N: usize = 20000;
         let watchable = Watchable::new(0u64);
@@ -1553,11 +1555,11 @@ mod tests {
             .ok();
         }
 
-        let mem_use_1 = procinfo::pid::statm_self().unwrap().resident - mem_baseline;
+        let mem_use_1 = process.statm().unwrap().resident - mem_baseline;
         // All N tasks completed and joined, yet their memory stays allocated;
         // `watchable.set(1)` frees all of it.
         watchable.set(1).unwrap();
-        let mem_use_2 = procinfo::pid::statm_self().unwrap().resident - mem_baseline;
+        let mem_use_2 = process.statm().unwrap().resident - mem_baseline;
         assert_eq!(
             mem_use_1, mem_use_2,
             "watchable.set(1) shouldn't free memory"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,6 @@
 #[cfg(not(watcher_loom))]
 use std::sync;
 use std::{
-    collections::VecDeque,
     future::Future,
     pin::Pin,
     sync::{Arc, RwLockReadGuard, Weak},
@@ -164,7 +163,7 @@ impl<T: Clone + Eq> Watchable<T> {
 
         // Notify watchers
         if changed {
-            for watcher in self.shared.wakers.lock().expect("poisoned").drain(..) {
+            for (_, watcher) in self.shared.wakers.lock().expect("poisoned").drain() {
                 watcher.wake();
             }
         }
@@ -176,6 +175,7 @@ impl<T: Clone + Eq> Watchable<T> {
         Direct {
             state: self.shared.state().clone(),
             shared: Some(Arc::downgrade(&self.shared)),
+            waker_key: None,
         }
     }
 
@@ -202,7 +202,7 @@ impl<T> Drop for Shared<T> {
         // the last `Watchable` is dropped).
         // This allows us to notify `NextFut::poll`s and have that
         // return `Disconnected`.
-        for watcher in watchers.drain(..) {
+        for (_, watcher) in watchers.drain() {
             watcher.wake();
         }
     }
@@ -386,14 +386,34 @@ pub trait Watcher: Clone {
 /// The immediate, direct observer of a [`Watchable`] value.
 ///
 /// This type is mainly used via the [`Watcher`] interface.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Direct<T> {
     state: State<T>,
-    // We wrap the Weak with an Option, so that we can set it to `None` once we
-    // notice that Weak is not upgradable anymore for the first time.
-    // This allows the weak pointer's allocation to be freed in case this makes
-    // the weak count go to zero (even if Direct is still kept around).
+    /// The reference of state shared with the connected [`Watchable`].
+    ///
+    /// We wrap the Weak with an Option, so that we can set it to `None` once we
+    /// notice that Weak is not upgradable anymore for the first time.
+    /// This allows the weak pointer's allocation to be freed in case this makes
+    /// the weak count go to zero (even if Direct is still kept around).
     shared: Option<Weak<Shared<T>>>,
+    /// The key we get when registering the waker.
+    ///
+    /// This allows us to tell `Shared` to remove our waker once we are
+    /// no longer interested in getting notified (i.e. on drop).
+    ///
+    /// Prevents leaking memory when constructing `Direct`s constantly, polling at
+    /// least once and then dropping them again.
+    waker_key: Option<slotmap::DefaultKey>,
+}
+
+impl<T: Clone> Clone for Direct<T> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            shared: self.shared.clone(),
+            waker_key: None,
+        }
+    }
 }
 
 impl<T: Clone + Eq> Watcher for Direct<T> {
@@ -429,8 +449,20 @@ impl<T: Clone + Eq> Watcher for Direct<T> {
             self.shared = None; // Weak won't be upgradable in the future, this way we can allow the allocation to be freed
             return Poll::Ready(Err(Disconnected));
         };
-        self.state = ready!(shared.poll_updated(cx, self.state.epoch));
+        self.state = ready!(shared.poll_updated(cx, self.state.epoch, &mut self.waker_key));
         Poll::Ready(Ok(()))
+    }
+}
+
+impl<T> Drop for Direct<T> {
+    fn drop(&mut self) {
+        let Some(shared) = self.shared.take().and_then(|weak| weak.upgrade()) else {
+            return;
+        };
+        let Some(key) = self.waker_key.take() else {
+            return;
+        };
+        shared.remove_waker(key);
     }
 }
 
@@ -764,7 +796,7 @@ const INITIAL_EPOCH: u64 = 1;
 struct Shared<T> {
     /// The value to be watched and its current epoch.
     state: RwLock<State<T>>,
-    wakers: Mutex<VecDeque<Waker>>,
+    wakers: Mutex<slotmap::DenseSlotMap<slotmap::DefaultKey, Waker>>,
 }
 
 #[derive(Debug, Clone)]
@@ -791,7 +823,12 @@ impl<T: Clone> Shared<T> {
         self.state.read().expect("poisoned")
     }
 
-    fn poll_updated(&self, cx: &mut task::Context<'_>, last_epoch: u64) -> Poll<State<T>> {
+    fn poll_updated(
+        &self,
+        cx: &mut task::Context<'_>,
+        last_epoch: u64,
+        waker_key: &mut Option<slotmap::DefaultKey>,
+    ) -> Poll<State<T>> {
         {
             let state = self.state();
 
@@ -802,7 +839,7 @@ impl<T: Clone> Shared<T> {
             }
         }
 
-        self.add_waker(cx);
+        *waker_key = Some(self.add_waker(cx));
 
         #[cfg(watcher_loom)]
         loom::thread::yield_now();
@@ -819,14 +856,30 @@ impl<T: Clone> Shared<T> {
         Poll::Pending
     }
 
-    fn add_waker(&self, cx: &mut task::Context<'_>) {
+    /// Adds the task's waker to this watchable.
+    ///
+    /// The waker will be woken when the watchable is dropped completely
+    /// or when the watcher is updated.
+    ///
+    /// Returns the key used in the waker slotmap.
+    /// This can be used to remove the waker if a notification is not
+    /// needed anymore.
+    fn add_waker(&self, cx: &mut task::Context<'_>) -> slotmap::DefaultKey {
         let mut wakers = self.wakers.lock().expect("poisoned");
-        for waker in wakers.iter() {
+        for (key, waker) in wakers.iter() {
             if waker.will_wake(cx.waker()) {
-                return;
+                return key;
             }
         }
-        wakers.push_back(cx.waker().clone());
+        wakers.insert(cx.waker().clone())
+    }
+}
+
+impl<T> Shared<T> {
+    /// Removes and optionally returns the waker that was added via [`Self::add_waker`] before.
+    fn remove_waker(&self, waker_key: slotmap::DefaultKey) -> Option<Waker> {
+        let mut wakers = self.wakers.lock().expect("poisoned");
+        wakers.remove(waker_key)
     }
 }
 
@@ -1471,5 +1524,43 @@ mod tests {
             .await
             .unwrap()
             .unwrap()
+    }
+
+    #[tokio::test]
+    async fn regression_memleak() {
+        let mem_baseline = procinfo::pid::statm_self().unwrap().resident;
+
+        const N: usize = 20000;
+        let watchable = Watchable::new(0u64);
+        for _ in 0..N {
+            let mut w = watchable.watch();
+            tokio::spawn(async move {
+                // Stand-in for a real future's state.
+                // Pushes this future beyond the size that makes tokio
+                // store this future boxed.
+                let pad = [0u8; 3600];
+                std::hint::black_box(&pad);
+                // Register the `Direct` as a future in this tokio task by polling once,
+                // but then end the task without waiting for wake.
+                tokio::select! {
+                    biased;
+                    _ = w.updated() => {}
+                    _ = std::future::ready(()) => {}
+                }
+                std::hint::black_box(&pad);
+            })
+            .await
+            .ok();
+        }
+
+        let mem_use_1 = procinfo::pid::statm_self().unwrap().resident - mem_baseline;
+        // All N tasks completed and joined, yet their memory stays allocated;
+        // `watchable.set(1)` frees all of it.
+        watchable.set(1).unwrap();
+        let mem_use_2 = procinfo::pid::statm_self().unwrap().resident - mem_baseline;
+        assert_eq!(
+            mem_use_1, mem_use_2,
+            "watchable.set(1) shouldn't free memory"
+        )
     }
 }


### PR DESCRIPTION
## Description

Fixes #62.

- Adds regression test
- Switches the underlying waker list implementation from `Mutex<VecDeque<Waker>>` to `Mutex<DenseSlotMap<Waker>>`.
- Adds an `impl Drop for Direct` that removes its current `Waker` from `Shared` state

## Breaking Changes

- There is now an `impl<T> Drop for Direct<T>`.
- None otherwise

## Notes & open questions

I *think* it's possible to break upstream code by adding a drop implementation to an existing struct, but IMO that's really an edge-case and releasing this change as a patch version bump is very much worth it.

I'm not sure how reliable the test that probes for current process memory use is going to be. On my system this works well. I'm not sure if there are similar checks we could do for windows or macos, but what the regression test checks should behave identically between all OSes.

I've run iroh's test suite (-p iroh and patchbay) with this branch's n0-watcher patched in and they pass.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
