### PR TITLE
fix: Count the number of wakers active in the same task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,25 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -90,17 +69,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,27 +88,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -179,16 +132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,16 +142,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "foldhash"
@@ -342,36 +275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,12 +328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "log"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,16 +360,6 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "n0-error"
@@ -523,7 +410,6 @@ dependencies = [
  "derive_more",
  "n0-error",
  "n0-future",
- "procfs",
  "rand",
  "slotmap",
  "tokio",
@@ -537,15 +423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -606,30 +483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "procfs"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
-dependencies = [
- "bitflags",
- "chrono",
- "flate2",
- "procfs-core",
- "rustix",
-]
-
-[[package]]
-name = "procfs-core"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
-dependencies = [
- "bitflags",
- "chrono",
- "hex",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,19 +538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
 ]
 
 [[package]]
@@ -780,12 +620,6 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1090,41 +924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,15 +934,6 @@ name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,6 @@ rand = "0.10"
 tokio = { version = "1", features = ["macros", "sync", "rt-multi-thread", "time", "test-util"] }
 tokio-util = { version = "0.7", features = ["io-util", "io", "rt"] }
 
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-procfs = "0.18.0"
-
 [lints.rust]
 missing_debug_implementations = "warn"
 # We have our own `watcher_loom` cfg to enable tokio-rs/loom testing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ impl<T: Clone + Eq> Watchable<T> {
     }
 
     #[cfg(test)]
-    fn debug_wake_counts(&self) -> Vec<u64> {
+    fn debug_waker_counts(&self) -> Vec<u64> {
         self.shared
             .wakers
             .lock()
@@ -895,11 +895,14 @@ impl<T> Shared<T> {
     /// Removes and optionally returns the waker that was added via [`Self::add_waker`] before.
     fn remove_waker(&self, waker_key: slotmap::DefaultKey) {
         let mut wakers = self.wakers.lock().expect("poisoned");
-        // We remove first instead of fetching the count first, as we expect count == 1
-        // to be the common case.
-        if let Some((waker, count)) = wakers.remove(waker_key) {
-            if count > 1 {
-                wakers.insert((waker, count - 1));
+        // We need to be careful to not use `remove` -> `insert` in favor of `get_mut`,
+        // because we care about the key the waker is stored under, as other watchers
+        // might still refer to the slot under that key.
+        if let Some((_, count)) = wakers.get_mut(waker_key) {
+            if *count <= 1 {
+                wakers.remove(waker_key);
+            } else {
+                *count -= 1;
             }
         }
     }
@@ -1644,6 +1647,32 @@ mod tests {
         }
         drop(watcher);
 
-        assert_eq!(watchable.debug_wake_counts(), vec![]);
+        assert_eq!(watchable.debug_waker_counts(), vec![]);
+    }
+
+    #[tokio::test]
+    async fn regression_waker_key_must_be_unchanged_on_remove() {
+        let watchable = Watchable::new(0u64);
+        let mut w1 = watchable.watch();
+        let mut w2 = watchable.watch();
+
+        // poll the watcher twice
+        tokio::select! {
+            biased;
+            _ = w1.updated() => {}
+            _ = w2.updated() => {}
+            _ = std::future::ready(()) => {}
+        }
+        assert_eq!(watchable.debug_waker_counts(), vec![2]);
+        drop(w2);
+        assert_eq!(watchable.debug_waker_counts(), vec![1]);
+        tokio::select! {
+            biased;
+            _ = w1.updated() => {}
+            _ = std::future::ready(()) => {}
+        }
+        assert_eq!(watchable.debug_waker_counts(), vec![1]);
+        drop(w1);
+        assert_eq!(watchable.debug_waker_counts(), vec![]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -890,7 +890,7 @@ impl<T: Clone> Shared<T> {
             if waker.will_wake(cx.waker()) {
                 if Some(key) != *waker_key {
                     *count = count.saturating_add(1);
-                    if let Some(old_key) = std::mem::replace(waker_key, Some(key)) {
+                    if let Some(old_key) = waker_key.replace(key) {
                         // This makes sure we clean up a potentially old waker we added previously.
                         Self::dec_or_rem_waker(&mut wakers, old_key);
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1656,7 +1656,7 @@ mod tests {
         let mut w1 = watchable.watch();
         let mut w2 = watchable.watch();
 
-        // poll the watcher twice
+        // register both watchers' wakers
         tokio::select! {
             biased;
             _ = w1.updated() => {}
@@ -1664,15 +1664,18 @@ mod tests {
             _ = std::future::ready(()) => {}
         }
         assert_eq!(watchable.debug_waker_counts(), vec![2]);
-        drop(w2);
+        drop(w2); // unregister one watcher
         assert_eq!(watchable.debug_waker_counts(), vec![1]);
+        // This used to add another count to the waker as
+        // unregistering one watcher used to swap out the key
+        // used for said waker.
         tokio::select! {
             biased;
             _ = w1.updated() => {}
             _ = std::future::ready(()) => {}
         }
         assert_eq!(watchable.debug_waker_counts(), vec![1]);
-        drop(w1);
+        drop(w1); // dropping the final waker should free the waker list
         assert_eq!(watchable.debug_waker_counts(), vec![]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,7 +898,7 @@ impl<T: Clone> Shared<T> {
                 return;
             }
         }
-        // There can be technical reasons why runtimes have `will_wake` false positives
+        // There can be technical reasons why runtimes have `will_wake` false negatives
         // (e.g. tokio root block_on wakers being on different CGUs in release mode) which
         // means we add a new waker every poll. This makes sure we clean up wakers from the
         // last poll call, if still present.
@@ -1580,22 +1580,15 @@ mod tests {
             .unwrap()
     }
 
-    #[cfg(target_os = "linux")]
     #[tokio::test]
-    async fn regression_memleak() {
-        let process = procfs::process::Process::myself().unwrap();
-        let mem_baseline = process.statm().unwrap().resident;
-
-        const N: usize = 20000;
+    async fn regression_completed_tasks_clean_up_wakers() {
+        const N: usize = 100;
         let watchable = Watchable::new(0u64);
+
+        let mut tasks = JoinSet::new();
         for _ in 0..N {
             let mut w = watchable.watch();
-            tokio::spawn(async move {
-                // Stand-in for a real future's state.
-                // Pushes this future beyond the size that makes tokio
-                // store this future boxed.
-                let pad = [0u8; 3600];
-                std::hint::black_box(&pad);
+            tasks.spawn(async move {
                 // Register the `Direct` as a future in this tokio task by polling once,
                 // but then end the task without waiting for wake.
                 tokio::select! {
@@ -1603,23 +1596,14 @@ mod tests {
                     _ = w.updated() => {}
                     _ = std::future::ready(()) => {}
                 }
-                std::hint::black_box(&pad);
-            })
-            .await
-            .ok();
+            });
         }
+        tasks.join_all().await;
 
-        let mem_use_1 = process.statm().unwrap().resident - mem_baseline;
         // All N tasks completed and joined. The watchable should not store any wakers.
         // Calling `watchable.set(1)` would drain all wakers. In a previous version that
         // list was non-empty here and draining it would free memory.
-        // In the current version nothing should change.
-        watchable.set(1).unwrap();
-        let mem_use_2 = process.statm().unwrap().resident - mem_baseline;
-        assert_eq!(
-            mem_use_1, mem_use_2,
-            "watchable.set(1) shouldn't free memory"
-        )
+        assert_eq!(watchable.debug_waker_counts(), vec![]);
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -807,6 +807,14 @@ const INITIAL_EPOCH: u64 = 1;
 struct Shared<T> {
     /// The value to be watched and its current epoch.
     state: RwLock<State<T>>,
+    /// Watcher wakers to be notified when this watchable is changed or dropped.
+    ///
+    /// We use a slotmap so we have a stable key we can store in the watcher for it to
+    /// remember which waker it previously inserted into the slot map.
+    /// We also store a u64 "reference count" of how many watchers have registered said
+    /// waker in the same task. This ensures we only remove the waker once the last
+    /// watcher from that task is dropped, while making sure that we don't register
+    /// wakers twice for the same task (saving memory).
     wakers: Mutex<slotmap::DenseSlotMap<slotmap::DefaultKey, (Waker, u64)>>,
 }
 
@@ -882,10 +890,20 @@ impl<T: Clone> Shared<T> {
             if waker.will_wake(cx.waker()) {
                 if Some(key) != *waker_key {
                     *count = count.saturating_add(1);
-                    *waker_key = Some(key);
+                    if let Some(old_key) = std::mem::replace(waker_key, Some(key)) {
+                        // This makes sure we clean up a potentially old waker we added previously.
+                        Self::dec_or_rem_waker(&mut wakers, old_key);
+                    }
                 }
                 return;
             }
+        }
+        // There can be technical reasons why runtimes have `will_wake` false positives
+        // (e.g. tokio root block_on wakers being on different CGUs in release mode) which
+        // means we add a new waker every poll. This makes sure we clean up wakers from the
+        // last poll call, if still present.
+        if let Some(old_key) = waker_key.take() {
+            Self::dec_or_rem_waker(&mut wakers, old_key);
         }
         *waker_key = Some(wakers.insert((cx.waker().clone(), 1)));
     }
@@ -895,6 +913,17 @@ impl<T> Shared<T> {
     /// Removes and optionally returns the waker that was added via [`Self::add_waker`] before.
     fn remove_waker(&self, waker_key: slotmap::DefaultKey) {
         let mut wakers = self.wakers.lock().expect("poisoned");
+        Self::dec_or_rem_waker(&mut wakers, waker_key);
+    }
+
+    /// Decrements the count of a waker entry, removing it when it reaches zero.
+    ///
+    /// Operates on an already-locked `wakers` guard to avoid re-entrant locking
+    /// from within [`Shared::add_waker`].
+    fn dec_or_rem_waker(
+        wakers: &mut slotmap::DenseSlotMap<slotmap::DefaultKey, (Waker, u64)>,
+        waker_key: slotmap::DefaultKey,
+    ) {
         // We need to be careful to not use `remove` -> `insert` in favor of `get_mut`,
         // because we care about the key the waker is stored under, as other watchers
         // might still refer to the slot under that key.
@@ -1663,9 +1692,13 @@ mod tests {
             _ = w2.updated() => {}
             _ = std::future::ready(()) => {}
         }
-        assert_eq!(watchable.debug_waker_counts(), vec![2]);
+        // we test the sum, because release and debug mode operate differently with tokio:
+        // In release mode, `will_wake` returns false negatives causing us to have [1, 1] waker counts,
+        // in debug mode, this doesn't happen, thus we're left with [2] as the waker counts.
+        // The reason for the difference is related to tokio waker vtables being split across CGUs.
+        assert_eq!(watchable.debug_waker_counts().iter().sum::<u64>(), 2);
         drop(w2); // unregister one watcher
-        assert_eq!(watchable.debug_waker_counts(), vec![1]);
+        assert_eq!(watchable.debug_waker_counts().iter().sum::<u64>(), 1);
         // This used to add another count to the waker as
         // unregistering one watcher used to swap out the key
         // used for said waker.
@@ -1674,7 +1707,7 @@ mod tests {
             _ = w1.updated() => {}
             _ = std::future::ready(()) => {}
         }
-        assert_eq!(watchable.debug_waker_counts(), vec![1]);
+        assert_eq!(watchable.debug_waker_counts().iter().sum::<u64>(), 1);
         drop(w1); // dropping the final waker should free the waker list
         assert_eq!(watchable.debug_waker_counts(), vec![]);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,8 @@ impl<T: Clone + Eq> Watchable<T> {
 
         // Notify watchers
         if changed {
-            for (_, watcher) in self.shared.wakers.lock().expect("poisoned").drain() {
-                watcher.wake();
+            for (_, (waker, _)) in self.shared.wakers.lock().expect("poisoned").drain() {
+                waker.wake();
             }
         }
         ret
@@ -195,15 +195,15 @@ impl<T: Clone + Eq> Watchable<T> {
 
 impl<T> Drop for Shared<T> {
     fn drop(&mut self) {
-        let Ok(mut watchers) = self.wakers.lock() else {
+        let Ok(mut wakers) = self.wakers.lock() else {
             return; // Poisoned waking?
         };
-        // Wake all watchers once we drop Shared (this happens when
+        // Wake all wakers once we drop Shared (this happens when
         // the last `Watchable` is dropped).
         // This allows us to notify `NextFut::poll`s and have that
         // return `Disconnected`.
-        for (_, watcher) in watchers.drain() {
-            watcher.wake();
+        for (_, (waker, _)) in wakers.drain() {
+            waker.wake();
         }
     }
 }
@@ -796,7 +796,7 @@ const INITIAL_EPOCH: u64 = 1;
 struct Shared<T> {
     /// The value to be watched and its current epoch.
     state: RwLock<State<T>>,
-    wakers: Mutex<slotmap::DenseSlotMap<slotmap::DefaultKey, Waker>>,
+    wakers: Mutex<slotmap::DenseSlotMap<slotmap::DefaultKey, (Waker, u64)>>,
 }
 
 #[derive(Debug, Clone)]
@@ -866,20 +866,27 @@ impl<T: Clone> Shared<T> {
     /// needed anymore.
     fn add_waker(&self, cx: &mut task::Context<'_>) -> slotmap::DefaultKey {
         let mut wakers = self.wakers.lock().expect("poisoned");
-        for (key, waker) in wakers.iter() {
+        for (key, (waker, count)) in wakers.iter_mut() {
             if waker.will_wake(cx.waker()) {
+                *count = count.saturating_add(1);
                 return key;
             }
         }
-        wakers.insert(cx.waker().clone())
+        wakers.insert((cx.waker().clone(), 1))
     }
 }
 
 impl<T> Shared<T> {
     /// Removes and optionally returns the waker that was added via [`Self::add_waker`] before.
-    fn remove_waker(&self, waker_key: slotmap::DefaultKey) -> Option<Waker> {
+    fn remove_waker(&self, waker_key: slotmap::DefaultKey) {
         let mut wakers = self.wakers.lock().expect("poisoned");
-        wakers.remove(waker_key)
+        // We remove first instead of fetching the count first, as we expect count == 1
+        // to be the common case.
+        if let Some((waker, count)) = wakers.remove(waker_key) {
+            if count > 1 {
+                wakers.insert((waker, count - 1));
+            }
+        }
     }
 }
 
@@ -1566,5 +1573,41 @@ mod tests {
             mem_use_1, mem_use_2,
             "watchable.set(1) shouldn't free memory"
         )
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn regression_same_task_drop_one_watcher_during_poll() {
+        struct SameTaskDropOneDirectDuringPoll {
+            watcher_1: Option<Direct<u64>>,
+            watcher_2: Direct<u64>,
+        }
+
+        impl Future for SameTaskDropOneDirectDuringPoll {
+            type Output = Result<(), Disconnected>;
+
+            fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+                // register a waker with both watchers
+                if let Some(watcher) = &mut self.watcher_1 {
+                    let _ = watcher.poll_updated(cx);
+                }
+                let res = self.watcher_2.poll_updated(cx);
+                self.watcher_1 = None; // drop watcher 1
+                res
+            }
+        }
+
+        let watcher = Watchable::new(0);
+        let weird = SameTaskDropOneDirectDuringPoll {
+            watcher_1: Some(watcher.watch()),
+            watcher_2: watcher.watch(),
+        };
+        let task = tokio::spawn(weird);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let _ = watcher.set(1);
+        tokio::time::timeout(Duration::from_millis(100), task)
+            .await
+            .unwrap() // no panic
+            .unwrap() // no timeout
+            .unwrap(); // no watcher disconnect
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,17 @@ impl<T: Clone + Eq> Watchable<T> {
         // `Direct`s watchers (which all watchers descend from) will increase the weak count
         Arc::weak_count(&self.shared) != 0
     }
+
+    #[cfg(test)]
+    fn debug_wake_counts(&self) -> Vec<u64> {
+        self.shared
+            .wakers
+            .lock()
+            .expect("poisoned")
+            .iter()
+            .map(|(_, (_, c))| *c)
+            .collect()
+    }
 }
 
 impl<T> Drop for Shared<T> {
@@ -839,7 +850,7 @@ impl<T: Clone> Shared<T> {
             }
         }
 
-        *waker_key = Some(self.add_waker(cx));
+        self.add_waker(cx, waker_key);
 
         #[cfg(watcher_loom)]
         loom::thread::yield_now();
@@ -861,18 +872,22 @@ impl<T: Clone> Shared<T> {
     /// The waker will be woken when the watchable is dropped completely
     /// or when the watcher is updated.
     ///
-    /// Returns the key used in the waker slotmap.
-    /// This can be used to remove the waker if a notification is not
-    /// needed anymore.
-    fn add_waker(&self, cx: &mut task::Context<'_>) -> slotmap::DefaultKey {
+    /// Will set `waker_key` to the key used in the waker slotmap.
+    /// `add_waker` needs to know the currently set waker key in order to
+    /// figure out whether it needs to increase the internal waker count
+    /// or not.
+    fn add_waker(&self, cx: &mut task::Context<'_>, waker_key: &mut Option<slotmap::DefaultKey>) {
         let mut wakers = self.wakers.lock().expect("poisoned");
         for (key, (waker, count)) in wakers.iter_mut() {
             if waker.will_wake(cx.waker()) {
-                *count = count.saturating_add(1);
-                return key;
+                if Some(key) != *waker_key {
+                    *count = count.saturating_add(1);
+                    *waker_key = Some(key);
+                }
+                return;
             }
         }
-        wakers.insert((cx.waker().clone(), 1))
+        *waker_key = Some(wakers.insert((cx.waker().clone(), 1)));
     }
 }
 
@@ -1609,5 +1624,26 @@ mod tests {
             .unwrap() // no panic
             .unwrap() // no timeout
             .unwrap(); // no watcher disconnect
+    }
+
+    #[tokio::test]
+    async fn regression_waker_count_stuck_on_double_poll() {
+        let watchable = Watchable::new(0u64);
+        let mut watcher = watchable.watch();
+
+        // poll the watcher twice
+        tokio::select! {
+            biased;
+            _ = watcher.updated() => {}
+            _ = std::future::ready(()) => {}
+        }
+        tokio::select! {
+            biased;
+            _ = watcher.updated() => {}
+            _ = std::future::ready(()) => {}
+        }
+        drop(watcher);
+
+        assert_eq!(watchable.debug_wake_counts(), vec![]);
     }
 }


### PR DESCRIPTION
## Description

- Goal: Only remove wakers from the list once no other waker is active in the same task for the same watchable.
- Adds a `count` to the slotmap for the number of wakers that all depend on getting woken by the same waker
- When `Direct` is dropped, we now check the count and insert the waker back if there are other directs waiting on notification.

## Breaking Changes

None

## Notes & open questions

I could have also skipped the `will_wake` check in `add_waker`, duplicating the wakers in the list, but this would lead to another slow leak. Using a counter avoids this.

The counter increases using `add_saturating` (even though it's a u64). In the worst case this means we would leave a task hanging that has >2^64 `Direct`s in the same task and drops all of them except one that it waits on. I think that's reasonable.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
