### PR TITLE
chore: run scheduled CI jobs earlier

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -4,8 +4,8 @@ name: Beta Rust
 
 on:
   schedule:
-    # 06:50 UTC every Monday
-    - cron: '50 6 * * 1'
+    # 03:50 UTC every Monday
+    - cron: '50 3 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -4,8 +4,8 @@ name: Cleanup
 
 on:
   schedule:
-    # 06:50 UTC every Monday
-    - cron: '50 6 * * 1'
+    # 03:50 UTC every Monday
+    - cron: '50 3 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -23,8 +23,8 @@ on:
   pull_request:
     types: [ 'labeled', 'unlabeled', 'opened', 'synchronize', 'reopened' ]
   schedule:
-    # 06:30 UTC every day
-    - cron: '30 6 * * *'
+    # 03:30 UTC every day
+    - cron: '30 3 * * *'
   workflow_dispatch:
     inputs:
       branch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "syn"


### PR DESCRIPTION
## Description

This moves scheduled CI jobs outside of engineering hours.

## Breaking Changes

n/a

## Notes & open questions

Also make cargo-deny happy by upgrading spin.

## Change checklist

- [x] Self-review.